### PR TITLE
Skip edge cases instead of throwing error

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -179,14 +179,14 @@ function addParentLabel() {
     // Parent label's Gmail ID (retrieve using index from name)
     let thisParent = label.replace("/" + label.split("/").pop(), "");
     let thisParentIndex = mylabels.findIndex(thisIndex => thisIndex.name == thisParent); 
-    let thisParentId = mylabels[thisParentIndex].id;
+    let thisParentId = mylabels[thisParentIndex]?.id;
 
     
     let thisQuery = "\-label:" + thisParent + " label:" + label; // this label but not its parent
 
     let msgList = Gmail.Users.Messages.list("me", { "q": thisQuery }).messages;  // list of matching messages
   
-    if (msgList) {
+    if (msgList && thisParentId > -1) {
       var allUpdates = +1;
       let thisLog = "";
     

--- a/Code.js
+++ b/Code.js
@@ -186,7 +186,7 @@ function addParentLabel() {
 
     let msgList = Gmail.Users.Messages.list("me", { "q": thisQuery }).messages;  // list of matching messages
   
-    if (msgList && thisParentId > -1) {
+    if (msgList && thisParentId) {
       var allUpdates = +1;
       let thisLog = "";
     


### PR DESCRIPTION
For some reason it can happen that the label isn't found in `mylabels` (`thisParentId` is **-1**). Skip these cases.

Additional notes: in my specific case this bug happened with labels added by _Gmelius_ (a third party service). Something in the way they added their labels to my account didn't play nice with the script, and I didn't have time to figure out why exactly. With this fix at least all other regular labels are processed correctly.